### PR TITLE
Creatures 1.1.2 universal binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+._*
+.LSOverride
+*~
+*.suo
+*.ncb
+*.perspectivev3
+*.pbxuser
+*.xcuserstate
+*.o
+build

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 *.perspectivev3
 *.pbxuser
 *.xcuserstate
+*.mode2
 *.o
 build

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@
 *.pbxuser
 *.xcuserstate
 *.mode2
+project.xcworkspace
+xcuserdata
 *.o
 build

--- a/Arena Classes/ComputingCreature.m
+++ b/Arena Classes/ComputingCreature.m
@@ -354,7 +354,7 @@ static float directionYArray[] =
 	x += directionXArray[moveDirection];
 	y += directionYArray[moveDirection];
 	
-	if(newCreature)
+	//if(newCreature)
 	{
 		int spawnMask = [arena spawnMask];
 		if(spawnMask & kSpawnMating)

--- a/CreatureController.h
+++ b/CreatureController.h
@@ -106,6 +106,7 @@ extern NSString * const CreatureNewArenaCreatedNotification;
 - (IBAction)registrationInfo:sender;
 
 - (IBAction)toolChanged:sender;
+- (void)changeTool:(int)index;
 
 - (IBAction)openArenaSettingsWindow:sender;
 - (IBAction)mutationRateChanged:sender;

--- a/CreatureController.h
+++ b/CreatureController.h
@@ -82,6 +82,7 @@ extern NSString * const CreatureNewArenaCreatedNotification;
 - (void)mouseUpAtPoint:(NSPoint)p;*/
 
 - (IBAction)toggleRun:(id)sender;
+- (void)stopRun:sender;
 - (IBAction)removeOldGenomes:sender;
 - (IBAction)setDisplayInterval:sender;
 - (void)setGenomeList:list;
@@ -90,6 +91,7 @@ extern NSString * const CreatureNewArenaCreatedNotification;
 - (void)runningUpdate;
 - (void)update;
 - (IBAction)update:sender;
+- (BOOL)askForSave;
 - (void)newArenaOK:sender;
 - (void)newArenaCancel:sender;
 - (IBAction)new:sender;

--- a/CreatureController.m
+++ b/CreatureController.m
@@ -206,7 +206,7 @@ NSString * const CreatureNewArenaCreatedNotification = @"CreatureNewArenaCreated
 	NSTimeInterval interval = 0;
 	if(displayInterval < 0)
 		interval = (1 << (-displayInterval - 1))/30.0; // -1 is 1/30th of a sec, -2 is 1/15th, etc.
-	else
+	else if(displayInterval <= 5)
 		interval = 1. / ((1 << displayInterval)*60.0);
 
 	[stepTimer invalidate];

--- a/CreatureController.m
+++ b/CreatureController.m
@@ -203,6 +203,8 @@ NSString * const CreatureNewArenaCreatedNotification = @"CreatureNewArenaCreated
 	NSTimeInterval interval = 0;
 	if(displayInterval < 0)
 		interval = (1 << (-displayInterval - 1))/30.0; // -1 is 1/30th of a sec, -2 is 1/15th, etc.
+	else
+		interval = 1. / ((1 << displayInterval)*60.0);
 
 	[stepTimer invalidate];
 	stepTimer = [NSTimer timerWithTimeInterval:interval target:self selector:@selector(step) userInfo:nil repeats:YES];

--- a/CreatureController.m
+++ b/CreatureController.m
@@ -195,6 +195,9 @@ NSString * const CreatureNewArenaCreatedNotification = @"CreatureNewArenaCreated
 
 	[FamilyTreeWindowController reset];
 	
+	// Select inspect tool after loading a file.
+	[self changeTool:3];
+	
 	return YES;
 }
 
@@ -424,12 +427,20 @@ NSString * const CreatureNewArenaCreatedNotification = @"CreatureNewArenaCreated
 	[sp setRequiredFileType:@"creatures"];
 
 	/* display the NSSavePanel */
-	NSString *oldFilename;
+	NSString *oldDirectory = nil;
+	NSString *oldFilename = @"";
 	if(hasBeenSaved)
+	{
 		oldFilename = [[view window] representedFilename];
-	else
-		oldFilename = @"";
-	runResult = [sp runModalForDirectory:nil file:oldFilename];
+		NSRange range = [oldFilename rangeOfString:@"/" options:NSBackwardsSearch];
+		if( range.location != NSNotFound )
+		{
+			oldDirectory = [oldFilename substringToIndex:range.location];
+			oldFilename = [oldFilename substringFromIndex:range.location+1];
+		}
+	}
+	
+	runResult = [sp runModalForDirectory:oldDirectory file:oldFilename];
 
 	/* if successful, save file under designated name */
 	if (runResult == NSOKButton) {
@@ -577,6 +588,9 @@ NSString * const CreatureNewArenaCreatedNotification = @"CreatureNewArenaCreated
 	[view setNeedsDisplay:YES];
 	step = 0;
 	[self update];
+	
+	// Select square tool after creating a new arena.
+	[self changeTool:2];
 }
 
 - (IBAction)save:sender
@@ -663,6 +677,13 @@ NSString * const CreatureNewArenaCreatedNotification = @"CreatureNewArenaCreated
 	}
 	if([tool respondsToSelector:@selector(selected:)])
 		[tool selected:nil];
+}
+
+
+- (void)changeTool:(int)index
+{
+	[toolSelectMatrix selectCellAtRow:0 column:index];
+	[self toolChanged:nil];
 }
 
 

--- a/Creatures.xcodeproj/project.pbxproj
+++ b/Creatures.xcodeproj/project.pbxproj
@@ -6,146 +6,7 @@
 	objectVersion = 42;
 	objects = {
 
-/* Begin PBXApplicationTarget section */
-		29B97326FDCFA39411CA2CEA /* Creatures */ = {
-			isa = PBXApplicationTarget;
-			buildConfigurationList = C2B8417C093C94EA00975D56 /* Build configuration list for PBXApplicationTarget "Creatures" */;
-			buildPhases = (
-				29B97327FDCFA39411CA2CEA /* Headers */,
-				29B97328FDCFA39411CA2CEA /* Resources */,
-				29B9732BFDCFA39411CA2CEA /* Sources */,
-				29B9732DFDCFA39411CA2CEA /* Frameworks */,
-			);
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					"$(SYSTEM_DEVELOPER_DIR)/SDKs/MacOSX10.2.7.sdk/usr/lib",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
-				PRECOMPILE_PREFIX_HEADER = YES;
-				PREFIX_HEADER = Creatures_Prefix.h;
-				PRODUCT_NAME = Creatures;
-				SECTORDER_FLAGS = "";
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-				);
-				WRAPPER_EXTENSION = app;
-			};
-			dependencies = (
-			);
-			name = Creatures;
-			productInstallPath = "$(HOME)/Applications";
-			productName = Creatures;
-			productReference = 17587328FF379C6511CA2CBB /* Creatures.app */;
-			productSettingsXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
-<!DOCTYPE plist PUBLIC \"-//Apple Computer//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
-<plist version=\"1.0\">
-<dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
-	<key>CFBundleDocumentTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeExtensions</key>
-			<array>
-				<string>creatures</string>
-			</array>
-			<key>CFBundleTypeIconFile</key>
-			<string>CreaturesDocument.icns</string>
-			<key>CFBundleTypeName</key>
-			<string>Creatures World</string>
-			<key>CFBundleTypeOSTypes</key>
-			<array>
-				<string>????</string>
-			</array>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-		</dict>
-	</array>
-	<key>CFBundleExecutable</key>
-	<string>Creatures</string>
-	<key>CFBundleGetInfoString</key>
-	<string>Creatures beta 4, Copyright 2003 Michael Ash</string>
-	<key>CFBundleIconFile</key>
-	<string>Creatures.icns</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.mikeash.Creatures</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>Creatures</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>Creatures beta 4</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>b4</string>
-	<key>NSMainNibFile</key>
-	<string>MainMenu</string>
-	<key>NSPrincipalClass</key>
-	<string>MyApplication</string>
-</dict>
-</plist>
-";
-		};
-/* End PBXApplicationTarget section */
-
 /* Begin PBXBuildFile section */
-		080E96DCFE201CFB7F000001 /* MainMenu.nib in Resources */ = {isa = PBXBuildFile; fileRef = 29B97318FDCFA39411CA2CEA /* MainMenu.nib */; };
-		089C165EFE840E0CC02AAC07 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
-		1058C7A3FEA54F0111CA2CBB /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
-		29B9732CFDCFA39411CA2CEA /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
-		C203017204F42A5F00A800F6 /* Creatures.icns in Resources */ = {isa = PBXBuildFile; fileRef = C203017104F42A5F00A800F6 /* Creatures.icns */; };
-		C204BED104901F23000001C9 /* Arena.h in Headers */ = {isa = PBXBuildFile; fileRef = C204BEC904901F23000001C9 /* Arena.h */; };
-		C204BED204901F23000001C9 /* Barrier.h in Headers */ = {isa = PBXBuildFile; fileRef = C204BECA04901F23000001C9 /* Barrier.h */; };
-		C204BED304901F23000001C9 /* ComputingCreature.m in Sources */ = {isa = PBXBuildFile; fileRef = C204BECB04901F23000001C9 /* ComputingCreature.m */; };
-		C204BED404901F23000001C9 /* Creature.m in Sources */ = {isa = PBXBuildFile; fileRef = C204BECC04901F23000001C9 /* Creature.m */; };
-		C204BED504901F23000001C9 /* Creature.h in Headers */ = {isa = PBXBuildFile; fileRef = C204BECD04901F23000001C9 /* Creature.h */; };
-		C204BED604901F23000001C9 /* Arena.m in Sources */ = {isa = PBXBuildFile; fileRef = C204BECE04901F23000001C9 /* Arena.m */; };
-		C204BED704901F23000001C9 /* ComputingCreature.h in Headers */ = {isa = PBXBuildFile; fileRef = C204BECF04901F23000001C9 /* ComputingCreature.h */; };
-		C204BED804901F23000001C9 /* Barrier.m in Sources */ = {isa = PBXBuildFile; fileRef = C204BED004901F23000001C9 /* Barrier.m */; };
-		C204DE09054159F0000001C9 /* zoom_out_cursor.png in Resources */ = {isa = PBXBuildFile; fileRef = C204DE07054159F0000001C9 /* zoom_out_cursor.png */; };
-		C204DE0A054159F0000001C9 /* zoom_in_cursor.png in Resources */ = {isa = PBXBuildFile; fileRef = C204DE08054159F0000001C9 /* zoom_in_cursor.png */; };
-		C204DE0C05415FAE000001C9 /* CreaturesDocument.icns in Resources */ = {isa = PBXBuildFile; fileRef = C204DE0B05415FAE000001C9 /* CreaturesDocument.icns */; };
-		C2279C2904BD356F000001C9 /* line_tool.tiff in Resources */ = {isa = PBXBuildFile; fileRef = C2279C2504BD356F000001C9 /* line_tool.tiff */; };
-		C2279C2A04BD356F000001C9 /* inspector_cursor.tiff in Resources */ = {isa = PBXBuildFile; fileRef = C2279C2604BD356F000001C9 /* inspector_cursor.tiff */; };
-		C2279C2B04BD3570000001C9 /* hand_cursor.tiff in Resources */ = {isa = PBXBuildFile; fileRef = C2279C2704BD356F000001C9 /* hand_cursor.tiff */; };
-		C2279C2C04BD3570000001C9 /* square_tool.tiff in Resources */ = {isa = PBXBuildFile; fileRef = C2279C2804BD356F000001C9 /* square_tool.tiff */; };
-		C22FFE1E0438D8B100D0BAF5 /* Language Reference in Resources */ = {isa = PBXBuildFile; fileRef = C22FFE1D0438D8B100D0BAF5 /* Language Reference */; };
-		C243A1A005380D95000001C9 /* Creatures.png in Resources */ = {isa = PBXBuildFile; fileRef = C243A19F05380D95000001C9 /* Creatures.png */; };
-		C243A1A205380DAA000001C9 /* Creatures.png in Resources */ = {isa = PBXBuildFile; fileRef = C243A1A105380DAA000001C9 /* Creatures.png */; };
-		C243A1A505381585000001C9 /* ErrorPanel.nib in Resources */ = {isa = PBXBuildFile; fileRef = C243A1A305381585000001C9 /* ErrorPanel.nib */; };
-		C243A1A80538185A000001C9 /* ErrorPanelController.h in Headers */ = {isa = PBXBuildFile; fileRef = C243A1A60538185A000001C9 /* ErrorPanelController.h */; };
-		C243A1A90538185A000001C9 /* ErrorPanelController.m in Sources */ = {isa = PBXBuildFile; fileRef = C243A1A70538185A000001C9 /* ErrorPanelController.m */; };
-		C243A1B2053835DB000001C9 /* MyApplication.h in Headers */ = {isa = PBXBuildFile; fileRef = C243A1B0053835DB000001C9 /* MyApplication.h */; };
-		C243A1B3053835DB000001C9 /* MyApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = C243A1B1053835DB000001C9 /* MyApplication.m */; };
-		C2442373053DB719000001C9 /* libcrypto.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C2442372053DB719000001C9 /* libcrypto.dylib */; };
-		C2442378053DC91A000001C9 /* EnterRegistration.nib in Resources */ = {isa = PBXBuildFile; fileRef = C2442376053DC919000001C9 /* EnterRegistration.nib */; };
-		C244237B053DC9E4000001C9 /* EnterRegistrationController.h in Headers */ = {isa = PBXBuildFile; fileRef = C2442379053DC9E3000001C9 /* EnterRegistrationController.h */; };
-		C244237C053DC9E4000001C9 /* EnterRegistrationController.m in Sources */ = {isa = PBXBuildFile; fileRef = C244237A053DC9E4000001C9 /* EnterRegistrationController.m */; };
-		C245EFE704FF1B6200A800F6 /* NSViewAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C245EFE504FF1B6200A800F6 /* NSViewAdditions.h */; };
-		C245EFE804FF1B6200A800F6 /* NSViewAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C245EFE604FF1B6200A800F6 /* NSViewAdditions.m */; };
-		C24C892A056D30850075603A /* MAStringTable.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C891C056D30840075603A /* MAStringTable.m */; };
-		C24C892B056D30850075603A /* MAStringTable.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C891D056D30840075603A /* MAStringTable.h */; };
-		C24C892C056D30850075603A /* MAObjectStack.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C891E056D30840075603A /* MAObjectStack.m */; };
-		C24C892D056D30850075603A /* MAObjectStack.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C891F056D30840075603A /* MAObjectStack.h */; };
-		C24C892E056D30850075603A /* MAObjectSet.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C8920056D30840075603A /* MAObjectSet.m */; };
-		C24C892F056D30850075603A /* MAObjectSet.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8921056D30840075603A /* MAObjectSet.h */; };
-		C24C8930056D30850075603A /* MAObjectOffsetTable.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C8922056D30840075603A /* MAObjectOffsetTable.m */; };
-		C24C8931056D30850075603A /* MAObjectOffsetTable.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8923056D30840075603A /* MAObjectOffsetTable.h */; };
-		C24C8932056D30850075603A /* MAObjectOffsetStack.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C8924056D30840075603A /* MAObjectOffsetStack.m */; };
-		C24C8933056D30850075603A /* MAObjectOffsetStack.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8925056D30840075603A /* MAObjectOffsetStack.h */; };
-		C24C8934056D30850075603A /* MAKeyedUnarchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C8926056D30840075603A /* MAKeyedUnarchiver.m */; };
-		C24C8935056D30850075603A /* MAKeyedUnarchiver.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8927056D30840075603A /* MAKeyedUnarchiver.h */; };
-		C24C8936056D30850075603A /* MAKeyedArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C8928056D30840075603A /* MAKeyedArchiver.m */; };
-		C24C8937056D30850075603A /* MAKeyedArchiver.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8929056D30840075603A /* MAKeyedArchiver.h */; };
 		C24C8938056D30850075603A /* MAStringTable.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C891C056D30840075603A /* MAStringTable.m */; };
 		C24C8939056D30850075603A /* MAStringTable.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C891D056D30840075603A /* MAStringTable.h */; };
 		C24C893A056D30850075603A /* MAObjectStack.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C891E056D30840075603A /* MAObjectStack.m */; };
@@ -160,36 +21,9 @@
 		C24C8943056D30850075603A /* MAKeyedUnarchiver.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8927056D30840075603A /* MAKeyedUnarchiver.h */; };
 		C24C8944056D30850075603A /* MAKeyedArchiver.m in Sources */ = {isa = PBXBuildFile; fileRef = C24C8928056D30840075603A /* MAKeyedArchiver.m */; };
 		C24C8945056D30850075603A /* MAKeyedArchiver.h in Headers */ = {isa = PBXBuildFile; fileRef = C24C8929056D30840075603A /* MAKeyedArchiver.h */; };
-		C24D54BE0546935700DF1631 /* CornerViewScrollView.h in Headers */ = {isa = PBXBuildFile; fileRef = C24D54BC0546935700DF1631 /* CornerViewScrollView.h */; };
-		C24D54BF0546935700DF1631 /* CornerViewScrollView.m in Sources */ = {isa = PBXBuildFile; fileRef = C24D54BD0546935700DF1631 /* CornerViewScrollView.m */; };
-		C24FD66B05547567007784F8 /* controlpanelscreenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = C24FD66A05547567007784F8 /* controlpanelscreenshot.png */; };
 		C24FD66C05547567007784F8 /* controlpanelscreenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = C24FD66A05547567007784F8 /* controlpanelscreenshot.png */; };
-		C27BE7CE053EBD16000001C9 /* RegistrationSplashController.h in Headers */ = {isa = PBXBuildFile; fileRef = C27BE7CC053EBD16000001C9 /* RegistrationSplashController.h */; };
-		C27BE7CF053EBD16000001C9 /* RegistrationSplashController.m in Sources */ = {isa = PBXBuildFile; fileRef = C27BE7CD053EBD16000001C9 /* RegistrationSplashController.m */; };
-		C27BE7D2053EC3F9000001C9 /* RegistrationSplash.nib in Resources */ = {isa = PBXBuildFile; fileRef = C27BE7D0053EC3F9000001C9 /* RegistrationSplash.nib */; };
-		C27E7AEF04DE94EC00A800F6 /* ZoomTool.h in Headers */ = {isa = PBXBuildFile; fileRef = C27E7AED04DE94EC00A800F6 /* ZoomTool.h */; };
-		C27E7AF004DE94EC00A800F6 /* ZoomTool.m in Sources */ = {isa = PBXBuildFile; fileRef = C27E7AEE04DE94EC00A800F6 /* ZoomTool.m */; };
-		C27E7B1304E2914F00A800F6 /* Debug.h in Headers */ = {isa = PBXBuildFile; fileRef = C27E7B1104E2914F00A800F6 /* Debug.h */; };
-		C27E7B1404E2914F00A800F6 /* Debug.m in Sources */ = {isa = PBXBuildFile; fileRef = C27E7B1204E2914F00A800F6 /* Debug.m */; };
-		C27E7B1604E2B5A200A800F6 /* Creatures_Prefix.h in Headers */ = {isa = PBXBuildFile; fileRef = C27E7B1504E2B5A200A800F6 /* Creatures_Prefix.h */; };
-		C27E7B1D04E3E22C00A800F6 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = C27E7B1C04E3E22C00A800F6 /* index.html */; };
 		C280144D056D74C600A1C266 /* MANSDataAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C280144B056D74C600A1C266 /* MANSDataAdditions.h */; };
 		C280144E056D74C600A1C266 /* MANSDataAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C280144C056D74C600A1C266 /* MANSDataAdditions.m */; };
-		C280144F056D74C600A1C266 /* MANSDataAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = C280144B056D74C600A1C266 /* MANSDataAdditions.h */; };
-		C2801450056D74C600A1C266 /* MANSDataAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = C280144C056D74C600A1C266 /* MANSDataAdditions.m */; };
-		C2846CBF0470AA0800000102 /* Guide.txt in Resources */ = {isa = PBXBuildFile; fileRef = C2846CBE0470AA0800000102 /* Guide.txt */; };
-		C28FACF404DBAAE800A800F6 /* Credits.rtf in Resources */ = {isa = PBXBuildFile; fileRef = C28FACF304DBAAE800A800F6 /* Credits.rtf */; };
-		C28FAD0004DBB59200A800F6 /* arenascreenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACF704DBB59200A800F6 /* arenascreenshot.png */; };
-		C28FAD0104DBB59300A800F6 /* arenasettings.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACF804DBB59200A800F6 /* arenasettings.png */; };
-		C28FAD0204DBB59300A800F6 /* drawscreenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACF904DBB59200A800F6 /* drawscreenshot.png */; };
-		C28FAD0304DBB59300A800F6 /* familytree.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACFA04DBB59200A800F6 /* familytree.png */; };
-		C28FAD0404DBB59300A800F6 /* genomeassembler.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACFB04DBB59200A800F6 /* genomeassembler.png */; };
-		C28FAD0504DBB59300A800F6 /* genomelist.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACFC04DBB59200A800F6 /* genomelist.png */; };
-		C28FAD0604DBB59300A800F6 /* genomewindow.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FACFD04DBB59200A800F6 /* genomewindow.png */; };
-		C28FAD0704DBB59400A800F6 /* help.html in Resources */ = {isa = PBXBuildFile; fileRef = C28FACFE04DBB59200A800F6 /* help.html */; };
-		C28FAD0904DBC07600A800F6 /* help_language_reference.html in Resources */ = {isa = PBXBuildFile; fileRef = C28FAD0804DBC07600A800F6 /* help_language_reference.html */; };
-		C28FAD0C04DBED0600A800F6 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = C28FAD0B04DBED0600A800F6 /* index.html */; };
-		C28FAD0E04DBED2100A800F6 /* screenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FAD0D04DBED2100A800F6 /* screenshot.png */; };
 		C29E01A30546DBE700B0215B /* CreaturesView.h in Headers */ = {isa = PBXBuildFile; fileRef = F52D6AC8018887C301AFB2DA /* CreaturesView.h */; };
 		C29E01A40546DBE700B0215B /* Genome.h in Headers */ = {isa = PBXBuildFile; fileRef = F52D6AFA018B664301AFB2DA /* Genome.h */; };
 		C29E01A50546DBE700B0215B /* GenomeListController.h in Headers */ = {isa = PBXBuildFile; fileRef = F52D6B01018C3EF001AFB2DA /* GenomeListController.h */; };
@@ -322,125 +156,15 @@
 		C29E02310546DBE700B0215B /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2ED5AA304B401F400F9CE20 /* Carbon.framework */; };
 		C29E02320546DBE700B0215B /* QuickTime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2ED5AA504B4025B00F9CE20 /* QuickTime.framework */; };
 		C29E02350546DBE700B0215B /* libcrypto.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C2442372053DB719000001C9 /* libcrypto.dylib */; };
-		C2B5267D04BCF1B5000001C9 /* GenomeBox.h in Headers */ = {isa = PBXBuildFile; fileRef = C2B5267B04BCF1B5000001C9 /* GenomeBox.h */; };
-		C2B5267E04BCF1B5000001C9 /* GenomeBox.m in Sources */ = {isa = PBXBuildFile; fileRef = C2B5267C04BCF1B5000001C9 /* GenomeBox.m */; };
-		C2C0C21805375317000001C9 /* creatureinspectorwindow.png in Resources */ = {isa = PBXBuildFile; fileRef = C2C0C21705375316000001C9 /* creatureinspectorwindow.png */; };
-		C2CC0AF204BCD35F000001C9 /* HandTool.h in Headers */ = {isa = PBXBuildFile; fileRef = C2CC0AF004BCD35F000001C9 /* HandTool.h */; };
-		C2CC0AF304BCD35F000001C9 /* HandTool.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CC0AF104BCD35F000001C9 /* HandTool.m */; };
-		C2CFD1E404900C3D000001C9 /* GenomeDragAcceptTextField.h in Headers */ = {isa = PBXBuildFile; fileRef = C2CFD1E204900C3D000001C9 /* GenomeDragAcceptTextField.h */; };
-		C2CFD1E504900C3D000001C9 /* GenomeDragAcceptTextField.m in Sources */ = {isa = PBXBuildFile; fileRef = C2CFD1E304900C3D000001C9 /* GenomeDragAcceptTextField.m */; };
-		C2D39CCB04D4FA8000A800F6 /* SimpleWebController.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D39CC904D4FA8000A800F6 /* SimpleWebController.h */; };
-		C2D39CCC04D4FA8000A800F6 /* SimpleWebController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D39CCA04D4FA8000A800F6 /* SimpleWebController.m */; };
-		C2D4BC95048C7500000001C9 /* GenomeAssemblerController.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D4BC93048C7500000001C9 /* GenomeAssemblerController.h */; };
-		C2D4BC96048C7500000001C9 /* GenomeAssemblerController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D4BC94048C7500000001C9 /* GenomeAssemblerController.m */; };
-		C2D4BC9B048D0BD9000001C9 /* VirtualMachineError.h in Headers */ = {isa = PBXBuildFile; fileRef = C2D4BC99048D0BD9000001C9 /* VirtualMachineError.h */; };
-		C2D4BC9C048D0BD9000001C9 /* VirtualMachineError.m in Sources */ = {isa = PBXBuildFile; fileRef = C2D4BC9A048D0BD9000001C9 /* VirtualMachineError.m */; };
-		C2D700AF05494F290052505E /* zoom_in_image.png in Resources */ = {isa = PBXBuildFile; fileRef = C2D700AD05494F290052505E /* zoom_in_image.png */; };
-		C2D700B005494F290052505E /* zoom_out_image.png in Resources */ = {isa = PBXBuildFile; fileRef = C2D700AE05494F290052505E /* zoom_out_image.png */; };
 		C2D700B105494F290052505E /* zoom_in_image.png in Resources */ = {isa = PBXBuildFile; fileRef = C2D700AD05494F290052505E /* zoom_in_image.png */; };
 		C2D700B205494F290052505E /* zoom_out_image.png in Resources */ = {isa = PBXBuildFile; fileRef = C2D700AE05494F290052505E /* zoom_out_image.png */; };
-		C2D700B405494F6C0052505E /* reload_image.png in Resources */ = {isa = PBXBuildFile; fileRef = C2D700B305494F6C0052505E /* reload_image.png */; };
 		C2D700B505494F6D0052505E /* reload_image.png in Resources */ = {isa = PBXBuildFile; fileRef = C2D700B305494F6C0052505E /* reload_image.png */; };
 		C2D9D4BD056D786D005964A3 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C2D9D4BC056D786D005964A3 /* libz.dylib */; };
-		C2D9D4BE056D786D005964A3 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = C2D9D4BC056D786D005964A3 /* libz.dylib */; };
-		C2E26E6104BE47AD000001C9 /* NoSelectionTableView.h in Headers */ = {isa = PBXBuildFile; fileRef = C2E26E5F04BE47AD000001C9 /* NoSelectionTableView.h */; };
-		C2E26E6204BE47AD000001C9 /* NoSelectionTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = C2E26E6004BE47AD000001C9 /* NoSelectionTableView.m */; };
-		C2E26E6504BE4C1B000001C9 /* GenomeLibrary.h in Headers */ = {isa = PBXBuildFile; fileRef = C2E26E6304BE4C1B000001C9 /* GenomeLibrary.h */; };
-		C2E26E6604BE4C1B000001C9 /* GenomeLibrary.m in Sources */ = {isa = PBXBuildFile; fileRef = C2E26E6404BE4C1B000001C9 /* GenomeLibrary.m */; };
-		C2E8F8B9047058E900000102 /* Report.txt in Resources */ = {isa = PBXBuildFile; fileRef = C2E8F8B8047058E900000102 /* Report.txt */; };
-		C2ED4CE60535F971000001C9 /* GenomeAssembler.nib in Resources */ = {isa = PBXBuildFile; fileRef = C2ED4CE50535F971000001C9 /* GenomeAssembler.nib */; };
-		C2ED4CE80535F97A000001C9 /* SimpleWebWindow.nib in Resources */ = {isa = PBXBuildFile; fileRef = C2ED4CE70535F97A000001C9 /* SimpleWebWindow.nib */; };
-		C2ED4CEB0535F9D8000001C9 /* CreatureInspectorWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = C2ED4CE90535F9D8000001C9 /* CreatureInspectorWindowController.h */; };
-		C2ED4CEC0535F9D8000001C9 /* CreatureInspectorWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = C2ED4CEA0535F9D8000001C9 /* CreatureInspectorWindowController.m */; };
-		C2ED5AA404B401F400F9CE20 /* Carbon.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2ED5AA304B401F400F9CE20 /* Carbon.framework */; };
-		C2ED5AA604B4025B00F9CE20 /* QuickTime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2ED5AA504B4025B00F9CE20 /* QuickTime.framework */; };
-		C2F8E24B046CA01200000103 /* VirtualMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = C2F8E247046CA01200000103 /* VirtualMachine.h */; };
-		C2F8E24C046CA01200000103 /* VirtualMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = C2F8E248046CA01200000103 /* VirtualMachine.m */; };
-		C2F8E24D046CA01200000103 /* VirtualMachineAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = C2F8E249046CA01200000103 /* VirtualMachineAssembler.h */; };
-		C2F8E24E046CA01200000103 /* VirtualMachineAssembler.m in Sources */ = {isa = PBXBuildFile; fileRef = C2F8E24A046CA01200000103 /* VirtualMachineAssembler.m */; };
-		C2F8E256046CB0F000000103 /* defaultprogram.txt in Resources */ = {isa = PBXBuildFile; fileRef = C2F8E255046CB0F000000103 /* defaultprogram.txt */; };
-		C2FDC9F005309C7E000001C9 /* ToolInteractionView.h in Headers */ = {isa = PBXBuildFile; fileRef = C2FDC9EE05309C7E000001C9 /* ToolInteractionView.h */; };
-		C2FDC9F105309C80000001C9 /* ToolInteractionView.m in Sources */ = {isa = PBXBuildFile; fileRef = C2FDC9EF05309C7E000001C9 /* ToolInteractionView.m */; };
-		C2FF619C05399E8A000001C9 /* TODO in Resources */ = {isa = PBXBuildFile; fileRef = C2FF619B05399E8A000001C9 /* TODO */; };
-		F52D6ACA018887C301AFB2DA /* CreaturesView.h in Headers */ = {isa = PBXBuildFile; fileRef = F52D6AC8018887C301AFB2DA /* CreaturesView.h */; };
-		F52D6ACB018887C301AFB2DA /* CreaturesView.m in Sources */ = {isa = PBXBuildFile; fileRef = F52D6AC9018887C301AFB2DA /* CreaturesView.m */; };
-		F52D6AF3018B4DE701AFB2DA /* Disassembly.nib in Resources */ = {isa = PBXBuildFile; fileRef = F52D6AF1018B4DE701AFB2DA /* Disassembly.nib */; };
-		F52D6AFC018B664301AFB2DA /* Genome.h in Headers */ = {isa = PBXBuildFile; fileRef = F52D6AFA018B664301AFB2DA /* Genome.h */; };
-		F52D6AFD018B664401AFB2DA /* Genome.m in Sources */ = {isa = PBXBuildFile; fileRef = F52D6AFB018B664301AFB2DA /* Genome.m */; };
-		F52D6B00018C334A01AFB2DA /* Genome.nib in Resources */ = {isa = PBXBuildFile; fileRef = F52D6AFE018C334A01AFB2DA /* Genome.nib */; };
-		F52D6B03018C3EF001AFB2DA /* GenomeListController.h in Headers */ = {isa = PBXBuildFile; fileRef = F52D6B01018C3EF001AFB2DA /* GenomeListController.h */; };
-		F52D6B04018C3EF001AFB2DA /* GenomeListController.m in Sources */ = {isa = PBXBuildFile; fileRef = F52D6B02018C3EF001AFB2DA /* GenomeListController.m */; };
-		F53274BA024555A401876B3C /* GenomeGraphic.h in Headers */ = {isa = PBXBuildFile; fileRef = F53274B8024555A401876B3C /* GenomeGraphic.h */; };
-		F53274BB024555A401876B3C /* GenomeGraphic.m in Sources */ = {isa = PBXBuildFile; fileRef = F53274B9024555A401876B3C /* GenomeGraphic.m */; };
-		F53274C6024745E701876B3C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = F53274C4024745E701876B3C /* Localizable.strings */; };
-		F548EEA601904F6F0158F8A2 /* GenomeWindow.nib in Resources */ = {isa = PBXBuildFile; fileRef = F548EEA401904F6F0158F8A2 /* GenomeWindow.nib */; };
-		F548EEAC019052B60158F8A2 /* GenomeWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = F548EEAA019052B60158F8A2 /* GenomeWindowController.h */; };
-		F548EEAD019052B60158F8A2 /* GenomeWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F548EEAB019052B60158F8A2 /* GenomeWindowController.m */; };
-		F55A29BC02B2E68C0100010A /* CreatureController.h in Headers */ = {isa = PBXBuildFile; fileRef = F55A29BA02B2E68C0100010A /* CreatureController.h */; };
-		F55A29BD02B2E68D0100010A /* CreatureController.m in Sources */ = {isa = PBXBuildFile; fileRef = F55A29BB02B2E68C0100010A /* CreatureController.m */; };
-		F5DAD45702BAA671014454CE /* PixmapUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = F5DAD45502BAA671014454CE /* PixmapUtils.h */; };
-		F5DAD45802BAA671014454CE /* PixmapUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DAD45602BAA671014454CE /* PixmapUtils.m */; };
-		F5DEE6420242B2CF01B86E95 /* FamilyTreeWindowController.h in Headers */ = {isa = PBXBuildFile; fileRef = F5DEE6400242B2CF01B86E95 /* FamilyTreeWindowController.h */; };
-		F5DEE6430242B2CF01B86E95 /* FamilyTreeWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DEE6410242B2CF01B86E95 /* FamilyTreeWindowController.m */; };
-		F5DEE6460242B37B01B86E95 /* FamilyTreeView.h in Headers */ = {isa = PBXBuildFile; fileRef = F5DEE6440242B37B01B86E95 /* FamilyTreeView.h */; };
-		F5DEE6470242B37B01B86E95 /* FamilyTreeView.m in Sources */ = {isa = PBXBuildFile; fileRef = F5DEE6450242B37B01B86E95 /* FamilyTreeView.m */; };
-		F5DEE64A0242B48801B86E95 /* FamilyTreeWindow.nib in Resources */ = {isa = PBXBuildFile; fileRef = F5DEE6480242B48801B86E95 /* FamilyTreeWindow.nib */; };
-		F5FCD5F802D8C4E00100010A /* log in Resources */ = {isa = PBXBuildFile; fileRef = F5FCD5F702D8C4E00100010A /* log */; };
-		F6365B2403D360CE018975DB /* GenomeGraphicView.nib in Resources */ = {isa = PBXBuildFile; fileRef = F6365B2203D360CE018975DB /* GenomeGraphicView.nib */; };
-		F6A0969903C78B26013EDAE9 /* RegionInspectorController.h in Headers */ = {isa = PBXBuildFile; fileRef = F6A0969703C78B26013EDAE9 /* RegionInspectorController.h */; };
-		F6A0969A03C78B26013EDAE9 /* RegionInspectorController.m in Sources */ = {isa = PBXBuildFile; fileRef = F6A0969803C78B26013EDAE9 /* RegionInspectorController.m */; };
-		F6A0969D03C7914C013EDAE9 /* RegionInspector.nib in Resources */ = {isa = PBXBuildFile; fileRef = F6A0969B03C7914C013EDAE9 /* RegionInspector.nib */; };
-		F6B33B1203C7327301A0E9AE /* SquareTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B1003C7327301A0E9AE /* SquareTool.h */; };
-		F6B33B1303C7327301A0E9AE /* SquareTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B1103C7327301A0E9AE /* SquareTool.m */; };
-		F6B33B1603C7328101A0E9AE /* DrawingTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B1403C7328101A0E9AE /* DrawingTool.h */; };
-		F6B33B1703C7328101A0E9AE /* DrawingTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B1503C7328101A0E9AE /* DrawingTool.m */; };
-		F6B33B1E03C73E2B01A0E9AE /* InspectTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B1C03C73E2B01A0E9AE /* InspectTool.h */; };
-		F6B33B1F03C73E2B01A0E9AE /* InspectTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B1D03C73E2B01A0E9AE /* InspectTool.m */; };
-		F6B33B2203C73FC301A0E9AE /* RegionTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B2003C73FC301A0E9AE /* RegionTool.h */; };
-		F6B33B2303C73FC301A0E9AE /* RegionTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B2103C73FC301A0E9AE /* RegionTool.m */; };
-		F6B33B2603C7414B01A0E9AE /* Region.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B2403C7414B01A0E9AE /* Region.h */; };
-		F6B33B2703C7414B01A0E9AE /* Region.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B2503C7414B01A0E9AE /* Region.m */; };
-		F6B33B2A03C7490901A0E9AE /* RegionCreateTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B2803C7490901A0E9AE /* RegionCreateTool.h */; };
-		F6B33B2B03C7490901A0E9AE /* RegionCreateTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B2903C7490901A0E9AE /* RegionCreateTool.m */; };
-		F6B33B3D03C752EA01A0E9AE /* RegionSelectTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6B33B3B03C752EA01A0E9AE /* RegionSelectTool.h */; };
-		F6B33B3E03C752EA01A0E9AE /* RegionSelectTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6B33B3C03C752EA01A0E9AE /* RegionSelectTool.m */; };
-		F6BE137E03D0C0C001DD2558 /* StackTrace.h in Headers */ = {isa = PBXBuildFile; fileRef = F6BE137C03D0C0C001DD2558 /* StackTrace.h */; };
-		F6BE137F03D0C0C001DD2558 /* StackTrace.m in Sources */ = {isa = PBXBuildFile; fileRef = F6BE137D03D0C0C001DD2558 /* StackTrace.m */; };
-		F6BE138603D0C0F101DD2558 /* ExceptionHandling.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F6BE138003D0C0F101DD2558 /* ExceptionHandling.framework */; };
-		F6EBE98203CC72EF0124F93A /* LineTool.h in Headers */ = {isa = PBXBuildFile; fileRef = F6EBE98003CC72EF0124F93A /* LineTool.h */; };
-		F6EBE98303CC72EF0124F93A /* LineTool.m in Sources */ = {isa = PBXBuildFile; fileRef = F6EBE98103CC72EF0124F93A /* LineTool.m */; };
 /* End PBXBuildFile section */
-
-/* Begin PBXBuildStyle section */
-		4A9504CCFFE6A4B311CA0CBA /* Development */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				OPTIMIZATION_CFLAGS = "-O0";
-				ZERO_LINK = NO;
-			};
-			name = Development;
-		};
-		4A9504CDFFE6A4B311CA0CBA /* Deployment */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_OPTIMIZATION_LEVEL = 3;
-				ZERO_LINK = NO;
-			};
-			name = Deployment;
-		};
-/* End PBXBuildStyle section */
 
 /* Begin PBXFileReference section */
 		089C165DFE840E0CC02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
-		17587328FF379C6511CA2CBB /* Creatures.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; path = Creatures.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		29B97316FDCFA39411CA2CEA /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		29B97319FDCFA39411CA2CEA /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.nib; name = English; path = English.lproj/MainMenu.nib; sourceTree = "<group>"; };
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
@@ -605,19 +329,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		29B9732DFDCFA39411CA2CEA /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				1058C7A3FEA54F0111CA2CBB /* Cocoa.framework in Frameworks */,
-				F6BE138603D0C0F101DD2558 /* ExceptionHandling.framework in Frameworks */,
-				C2ED5AA404B401F400F9CE20 /* Carbon.framework in Frameworks */,
-				C2ED5AA604B4025B00F9CE20 /* QuickTime.framework in Frameworks */,
-				C2442373053DB719000001C9 /* libcrypto.dylib in Frameworks */,
-				C2D9D4BE056D786D005964A3 /* libz.dylib in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C29E022E0546DBE700B0215B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -679,7 +390,6 @@
 		19C28FACFE9D520D11CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				17587328FF379C6511CA2CBB /* Creatures.app */,
 				C29E02380546DBE700B0215B /* Creatures.app */,
 			);
 			name = Products;
@@ -952,65 +662,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		29B97327FDCFA39411CA2CEA /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F52D6ACA018887C301AFB2DA /* CreaturesView.h in Headers */,
-				F52D6AFC018B664301AFB2DA /* Genome.h in Headers */,
-				F52D6B03018C3EF001AFB2DA /* GenomeListController.h in Headers */,
-				F548EEAC019052B60158F8A2 /* GenomeWindowController.h in Headers */,
-				F5DEE6420242B2CF01B86E95 /* FamilyTreeWindowController.h in Headers */,
-				F5DEE6460242B37B01B86E95 /* FamilyTreeView.h in Headers */,
-				F53274BA024555A401876B3C /* GenomeGraphic.h in Headers */,
-				F55A29BC02B2E68C0100010A /* CreatureController.h in Headers */,
-				F5DAD45702BAA671014454CE /* PixmapUtils.h in Headers */,
-				F6B33B1203C7327301A0E9AE /* SquareTool.h in Headers */,
-				F6B33B1603C7328101A0E9AE /* DrawingTool.h in Headers */,
-				F6B33B1E03C73E2B01A0E9AE /* InspectTool.h in Headers */,
-				F6B33B2203C73FC301A0E9AE /* RegionTool.h in Headers */,
-				F6B33B2603C7414B01A0E9AE /* Region.h in Headers */,
-				F6B33B2A03C7490901A0E9AE /* RegionCreateTool.h in Headers */,
-				F6B33B3D03C752EA01A0E9AE /* RegionSelectTool.h in Headers */,
-				F6A0969903C78B26013EDAE9 /* RegionInspectorController.h in Headers */,
-				F6EBE98203CC72EF0124F93A /* LineTool.h in Headers */,
-				F6BE137E03D0C0C001DD2558 /* StackTrace.h in Headers */,
-				C2F8E24B046CA01200000103 /* VirtualMachine.h in Headers */,
-				C2F8E24D046CA01200000103 /* VirtualMachineAssembler.h in Headers */,
-				C2D4BC95048C7500000001C9 /* GenomeAssemblerController.h in Headers */,
-				C2D4BC9B048D0BD9000001C9 /* VirtualMachineError.h in Headers */,
-				C2CFD1E404900C3D000001C9 /* GenomeDragAcceptTextField.h in Headers */,
-				C204BED104901F23000001C9 /* Arena.h in Headers */,
-				C204BED204901F23000001C9 /* Barrier.h in Headers */,
-				C204BED504901F23000001C9 /* Creature.h in Headers */,
-				C204BED704901F23000001C9 /* ComputingCreature.h in Headers */,
-				C2CC0AF204BCD35F000001C9 /* HandTool.h in Headers */,
-				C2B5267D04BCF1B5000001C9 /* GenomeBox.h in Headers */,
-				C2E26E6104BE47AD000001C9 /* NoSelectionTableView.h in Headers */,
-				C2E26E6504BE4C1B000001C9 /* GenomeLibrary.h in Headers */,
-				C2D39CCB04D4FA8000A800F6 /* SimpleWebController.h in Headers */,
-				C27E7AEF04DE94EC00A800F6 /* ZoomTool.h in Headers */,
-				C27E7B1304E2914F00A800F6 /* Debug.h in Headers */,
-				C27E7B1604E2B5A200A800F6 /* Creatures_Prefix.h in Headers */,
-				C245EFE704FF1B6200A800F6 /* NSViewAdditions.h in Headers */,
-				C2FDC9F005309C7E000001C9 /* ToolInteractionView.h in Headers */,
-				C2ED4CEB0535F9D8000001C9 /* CreatureInspectorWindowController.h in Headers */,
-				C243A1A80538185A000001C9 /* ErrorPanelController.h in Headers */,
-				C243A1B2053835DB000001C9 /* MyApplication.h in Headers */,
-				C244237B053DC9E4000001C9 /* EnterRegistrationController.h in Headers */,
-				C27BE7CE053EBD16000001C9 /* RegistrationSplashController.h in Headers */,
-				C24D54BE0546935700DF1631 /* CornerViewScrollView.h in Headers */,
-				C24C892B056D30850075603A /* MAStringTable.h in Headers */,
-				C24C892D056D30850075603A /* MAObjectStack.h in Headers */,
-				C24C892F056D30850075603A /* MAObjectSet.h in Headers */,
-				C24C8931056D30850075603A /* MAObjectOffsetTable.h in Headers */,
-				C24C8933056D30850075603A /* MAObjectOffsetStack.h in Headers */,
-				C24C8935056D30850075603A /* MAKeyedUnarchiver.h in Headers */,
-				C24C8937056D30850075603A /* MAKeyedArchiver.h in Headers */,
-				C280144F056D74C600A1C266 /* MANSDataAdditions.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C29E01A20546DBE700B0215B /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1073,9 +724,9 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		C29E01A10546DBE700B0215B /* Creatures (Upgraded) */ = {
+		C29E01A10546DBE700B0215B /* Creatures */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C2B84180093C94EA00975D56 /* Build configuration list for PBXNativeTarget "Creatures (Upgraded)" */;
+			buildConfigurationList = C2B84180093C94EA00975D56 /* Build configuration list for PBXNativeTarget "Creatures" */;
 			buildPhases = (
 				C29E01A20546DBE700B0215B /* Headers */,
 				C29E01D20546DBE700B0215B /* Resources */,
@@ -1084,31 +735,9 @@
 			);
 			buildRules = (
 			);
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "";
-				GCC_MODEL_PPC64 = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = Creatures_Prefix.h;
-				GCC_WARN_FOUR_CHARACTER_CONSTANTS = NO;
-				GCC_WARN_UNINITIALIZED_AUTOS = NO;
-				GCC_WARN_UNKNOWN_PRAGMAS = NO;
-				GCC_WARN_UNUSED_VALUE = NO;
-				HEADER_SEARCH_PATHS = "";
-				INFOPLIST_FILE = "Info-Creatures__Upgraded_.plist";
-				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
-				MACOSX_DEPLOYMENT_TARGET = 10.2;
-				PRODUCT_NAME = Creatures;
-				SECTORDER_FLAGS = "";
-				WARNING_CFLAGS = "-Wall";
-				WRAPPER_EXTENSION = app;
-			};
 			dependencies = (
 			);
-			name = "Creatures (Upgraded)";
+			name = Creatures;
 			productInstallPath = "$(HOME)/Applications";
 			productName = Creatures;
 			productReference = C29E02380546DBE700B0215B /* Creatures.app */;
@@ -1120,80 +749,25 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			buildConfigurationList = C2B84184093C94EA00975D56 /* Build configuration list for PBXProject "Creatures" */;
-			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.2;
-				SDKROOT = /Developer/SDKs/MacOSX10.2.8.sdk;
-			};
-			buildStyles = (
-				4A9504CCFFE6A4B311CA0CBA /* Development */,
-				4A9504CDFFE6A4B311CA0CBA /* Deployment */,
-			);
+			compatibilityVersion = "Xcode 2.4";
+			developmentRegion = English;
 			hasScannedForEncodings = 1;
+			knownRegions = (
+				English,
+				Japanese,
+				French,
+				German,
+			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* Creatures */;
 			projectDirPath = "";
+			projectRoot = "";
 			targets = (
-				29B97326FDCFA39411CA2CEA /* Creatures */,
-				C29E01A10546DBE700B0215B /* Creatures (Upgraded) */,
+				C29E01A10546DBE700B0215B /* Creatures */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		29B97328FDCFA39411CA2CEA /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				080E96DCFE201CFB7F000001 /* MainMenu.nib in Resources */,
-				089C165EFE840E0CC02AAC07 /* InfoPlist.strings in Resources */,
-				F52D6AF3018B4DE701AFB2DA /* Disassembly.nib in Resources */,
-				F52D6B00018C334A01AFB2DA /* Genome.nib in Resources */,
-				F548EEA601904F6F0158F8A2 /* GenomeWindow.nib in Resources */,
-				F5DEE64A0242B48801B86E95 /* FamilyTreeWindow.nib in Resources */,
-				F53274C6024745E701876B3C /* Localizable.strings in Resources */,
-				F5FCD5F802D8C4E00100010A /* log in Resources */,
-				F6A0969D03C7914C013EDAE9 /* RegionInspector.nib in Resources */,
-				F6365B2403D360CE018975DB /* GenomeGraphicView.nib in Resources */,
-				C22FFE1E0438D8B100D0BAF5 /* Language Reference in Resources */,
-				C2F8E256046CB0F000000103 /* defaultprogram.txt in Resources */,
-				C2E8F8B9047058E900000102 /* Report.txt in Resources */,
-				C2846CBF0470AA0800000102 /* Guide.txt in Resources */,
-				C2ED4CE60535F971000001C9 /* GenomeAssembler.nib in Resources */,
-				C2279C2904BD356F000001C9 /* line_tool.tiff in Resources */,
-				C2279C2A04BD356F000001C9 /* inspector_cursor.tiff in Resources */,
-				C2279C2B04BD3570000001C9 /* hand_cursor.tiff in Resources */,
-				C2279C2C04BD3570000001C9 /* square_tool.tiff in Resources */,
-				C2ED4CE80535F97A000001C9 /* SimpleWebWindow.nib in Resources */,
-				C28FACF404DBAAE800A800F6 /* Credits.rtf in Resources */,
-				C28FAD0004DBB59200A800F6 /* arenascreenshot.png in Resources */,
-				C28FAD0104DBB59300A800F6 /* arenasettings.png in Resources */,
-				C28FAD0204DBB59300A800F6 /* drawscreenshot.png in Resources */,
-				C28FAD0304DBB59300A800F6 /* familytree.png in Resources */,
-				C28FAD0404DBB59300A800F6 /* genomeassembler.png in Resources */,
-				C28FAD0504DBB59300A800F6 /* genomelist.png in Resources */,
-				C28FAD0604DBB59300A800F6 /* genomewindow.png in Resources */,
-				C28FAD0704DBB59400A800F6 /* help.html in Resources */,
-				C28FAD0904DBC07600A800F6 /* help_language_reference.html in Resources */,
-				C28FAD0C04DBED0600A800F6 /* index.html in Resources */,
-				C28FAD0E04DBED2100A800F6 /* screenshot.png in Resources */,
-				C27E7B1D04E3E22C00A800F6 /* index.html in Resources */,
-				C203017204F42A5F00A800F6 /* Creatures.icns in Resources */,
-				C2C0C21805375317000001C9 /* creatureinspectorwindow.png in Resources */,
-				C243A1A005380D95000001C9 /* Creatures.png in Resources */,
-				C243A1A205380DAA000001C9 /* Creatures.png in Resources */,
-				C243A1A505381585000001C9 /* ErrorPanel.nib in Resources */,
-				C2FF619C05399E8A000001C9 /* TODO in Resources */,
-				C2442378053DC91A000001C9 /* EnterRegistration.nib in Resources */,
-				C27BE7D2053EC3F9000001C9 /* RegistrationSplash.nib in Resources */,
-				C204DE09054159F0000001C9 /* zoom_out_cursor.png in Resources */,
-				C204DE0A054159F0000001C9 /* zoom_in_cursor.png in Resources */,
-				C204DE0C05415FAE000001C9 /* CreaturesDocument.icns in Resources */,
-				C2D700AF05494F290052505E /* zoom_in_image.png in Resources */,
-				C2D700B005494F290052505E /* zoom_out_image.png in Resources */,
-				C2D700B405494F6C0052505E /* reload_image.png in Resources */,
-				C24FD66B05547567007784F8 /* controlpanelscreenshot.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C29E01D20546DBE700B0215B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1247,65 +821,6 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		29B9732BFDCFA39411CA2CEA /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				29B9732CFDCFA39411CA2CEA /* main.m in Sources */,
-				F52D6ACB018887C301AFB2DA /* CreaturesView.m in Sources */,
-				F52D6AFD018B664401AFB2DA /* Genome.m in Sources */,
-				F52D6B04018C3EF001AFB2DA /* GenomeListController.m in Sources */,
-				F548EEAD019052B60158F8A2 /* GenomeWindowController.m in Sources */,
-				F5DEE6430242B2CF01B86E95 /* FamilyTreeWindowController.m in Sources */,
-				F5DEE6470242B37B01B86E95 /* FamilyTreeView.m in Sources */,
-				F53274BB024555A401876B3C /* GenomeGraphic.m in Sources */,
-				F55A29BD02B2E68D0100010A /* CreatureController.m in Sources */,
-				F5DAD45802BAA671014454CE /* PixmapUtils.m in Sources */,
-				F6B33B1303C7327301A0E9AE /* SquareTool.m in Sources */,
-				F6B33B1703C7328101A0E9AE /* DrawingTool.m in Sources */,
-				F6B33B1F03C73E2B01A0E9AE /* InspectTool.m in Sources */,
-				F6B33B2303C73FC301A0E9AE /* RegionTool.m in Sources */,
-				F6B33B2703C7414B01A0E9AE /* Region.m in Sources */,
-				F6B33B2B03C7490901A0E9AE /* RegionCreateTool.m in Sources */,
-				F6B33B3E03C752EA01A0E9AE /* RegionSelectTool.m in Sources */,
-				F6A0969A03C78B26013EDAE9 /* RegionInspectorController.m in Sources */,
-				F6EBE98303CC72EF0124F93A /* LineTool.m in Sources */,
-				F6BE137F03D0C0C001DD2558 /* StackTrace.m in Sources */,
-				C2F8E24C046CA01200000103 /* VirtualMachine.m in Sources */,
-				C2F8E24E046CA01200000103 /* VirtualMachineAssembler.m in Sources */,
-				C2D4BC96048C7500000001C9 /* GenomeAssemblerController.m in Sources */,
-				C2D4BC9C048D0BD9000001C9 /* VirtualMachineError.m in Sources */,
-				C2CFD1E504900C3D000001C9 /* GenomeDragAcceptTextField.m in Sources */,
-				C204BED304901F23000001C9 /* ComputingCreature.m in Sources */,
-				C204BED404901F23000001C9 /* Creature.m in Sources */,
-				C204BED604901F23000001C9 /* Arena.m in Sources */,
-				C204BED804901F23000001C9 /* Barrier.m in Sources */,
-				C2CC0AF304BCD35F000001C9 /* HandTool.m in Sources */,
-				C2B5267E04BCF1B5000001C9 /* GenomeBox.m in Sources */,
-				C2E26E6204BE47AD000001C9 /* NoSelectionTableView.m in Sources */,
-				C2E26E6604BE4C1B000001C9 /* GenomeLibrary.m in Sources */,
-				C2D39CCC04D4FA8000A800F6 /* SimpleWebController.m in Sources */,
-				C27E7AF004DE94EC00A800F6 /* ZoomTool.m in Sources */,
-				C27E7B1404E2914F00A800F6 /* Debug.m in Sources */,
-				C245EFE804FF1B6200A800F6 /* NSViewAdditions.m in Sources */,
-				C2FDC9F105309C80000001C9 /* ToolInteractionView.m in Sources */,
-				C2ED4CEC0535F9D8000001C9 /* CreatureInspectorWindowController.m in Sources */,
-				C243A1A90538185A000001C9 /* ErrorPanelController.m in Sources */,
-				C243A1B3053835DB000001C9 /* MyApplication.m in Sources */,
-				C244237C053DC9E4000001C9 /* EnterRegistrationController.m in Sources */,
-				C27BE7CF053EBD16000001C9 /* RegistrationSplashController.m in Sources */,
-				C24D54BF0546935700DF1631 /* CornerViewScrollView.m in Sources */,
-				C24C892A056D30850075603A /* MAStringTable.m in Sources */,
-				C24C892C056D30850075603A /* MAObjectStack.m in Sources */,
-				C24C892E056D30850075603A /* MAObjectSet.m in Sources */,
-				C24C8930056D30850075603A /* MAObjectOffsetTable.m in Sources */,
-				C24C8932056D30850075603A /* MAObjectOffsetStack.m in Sources */,
-				C24C8934056D30850075603A /* MAKeyedUnarchiver.m in Sources */,
-				C24C8936056D30850075603A /* MAKeyedArchiver.m in Sources */,
-				C2801450056D74C600A1C266 /* MANSDataAdditions.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		C29E02000546DBE700B0215B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1483,89 +998,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		C2B8417D093C94EA00975D56 /* Development */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				HEADER_SEARCH_PATHS = "";
-				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					"$(SYSTEM_DEVELOPER_DIR)/SDKs/MacOSX10.2.7.sdk/usr/lib",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
-				OPTIMIZATION_CFLAGS = "-O0";
-				PRECOMPILE_PREFIX_HEADER = YES;
-				PREFIX_HEADER = Creatures_Prefix.h;
-				PRODUCT_NAME = Creatures;
-				SECTORDER_FLAGS = "";
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-				);
-				WRAPPER_EXTENSION = app;
-				ZERO_LINK = NO;
-			};
-			name = Development;
-		};
-		C2B8417E093C94EA00975D56 /* Deployment */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = "";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
-				GCC_OPTIMIZATION_LEVEL = 3;
-				HEADER_SEARCH_PATHS = "";
-				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					"$(SYSTEM_DEVELOPER_DIR)/SDKs/MacOSX10.2.7.sdk/usr/lib",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
-				PRECOMPILE_PREFIX_HEADER = YES;
-				PREFIX_HEADER = Creatures_Prefix.h;
-				PRODUCT_NAME = Creatures;
-				SECTORDER_FLAGS = "";
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-				);
-				WRAPPER_EXTENSION = app;
-				ZERO_LINK = NO;
-			};
-			name = Deployment;
-		};
-		C2B8417F093C94EA00975D56 /* Default */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				FRAMEWORK_SEARCH_PATHS = "";
-				HEADER_SEARCH_PATHS = "";
-				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					"$(SYSTEM_DEVELOPER_DIR)/SDKs/MacOSX10.2.7.sdk/usr/lib",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
-				PRECOMPILE_PREFIX_HEADER = YES;
-				PREFIX_HEADER = Creatures_Prefix.h;
-				PRODUCT_NAME = Creatures;
-				SECTORDER_FLAGS = "";
-				WARNING_CFLAGS = (
-					"-Wall",
-					"-Wno-four-char-constants",
-					"-Wno-unknown-pragmas",
-				);
-				WRAPPER_EXTENSION = app;
-			};
-			name = Default;
-		};
 		C2B84181093C94EA00975D56 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1578,6 +1010,7 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Creatures_Prefix.h;
+				GCC_VERSION = 4.0;
 				GCC_WARN_FOUR_CHARACTER_CONSTANTS = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = NO;
 				GCC_WARN_UNKNOWN_PRAGMAS = NO;
@@ -1585,12 +1018,7 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "Info-Creatures__Upgraded_.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
 				MACOSX_DEPLOYMENT_TARGET = 10.2;
-				OPTIMIZATION_CFLAGS = "-O0";
 				PRODUCT_NAME = Creatures;
 				SECTORDER_FLAGS = "";
 				WARNING_CFLAGS = "-Wall";
@@ -1609,6 +1037,7 @@
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Creatures_Prefix.h;
+				GCC_VERSION = 4.0;
 				GCC_WARN_FOUR_CHARACTER_CONSTANTS = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = NO;
 				GCC_WARN_UNKNOWN_PRAGMAS = NO;
@@ -1616,10 +1045,6 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "Info-Creatures__Upgraded_.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
 				MACOSX_DEPLOYMENT_TARGET = 10.2;
 				PRODUCT_NAME = Creatures;
 				SECTORDER_FLAGS = "";
@@ -1636,6 +1061,7 @@
 				GCC_MODEL_PPC64 = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Creatures_Prefix.h;
+				GCC_VERSION = 4.0;
 				GCC_WARN_FOUR_CHARACTER_CONSTANTS = NO;
 				GCC_WARN_UNINITIALIZED_AUTOS = NO;
 				GCC_WARN_UNKNOWN_PRAGMAS = NO;
@@ -1643,10 +1069,6 @@
 				HEADER_SEARCH_PATHS = "";
 				INFOPLIST_FILE = "Info-Creatures__Upgraded_.plist";
 				INSTALL_PATH = "$(HOME)/Applications";
-				LIBRARY_SEARCH_PATHS = (
-					"$(SYSTEM_APPS_DIR)/eSellerate SDK/eSellerate Demos/GeckoSoft for Project Builder",
-					/Users/mikeash/Development/Projects/Creatures,
-				);
 				MACOSX_DEPLOYMENT_TARGET = 10.2;
 				PRODUCT_NAME = Creatures;
 				SECTORDER_FLAGS = "";
@@ -1658,41 +1080,46 @@
 		C2B84185093C94EA00975D56 /* Development */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.2;
-				SDKROOT = /Developer/SDKs/MacOSX10.2.8.sdk;
+				ARCHS = (
+					ppc,
+					i386,
+				);
+				GCC_VERSION = 4.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Development;
 		};
 		C2B84186093C94EA00975D56 /* Deployment */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.2;
-				SDKROOT = /Developer/SDKs/MacOSX10.2.8.sdk;
+				ARCHS = (
+					ppc,
+					i386,
+				);
+				GCC_VERSION = 4.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Deployment;
 		};
 		C2B84187093C94EA00975D56 /* Default */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				MACOSX_DEPLOYMENT_TARGET = 10.2;
-				SDKROOT = /Developer/SDKs/MacOSX10.2.8.sdk;
+				ARCHS = (
+					ppc,
+					i386,
+				);
+				GCC_VERSION = 4.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.4;
+				SDKROOT = /Developer/SDKs/MacOSX10.4u.sdk;
 			};
 			name = Default;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		C2B8417C093C94EA00975D56 /* Build configuration list for PBXApplicationTarget "Creatures" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				C2B8417D093C94EA00975D56 /* Development */,
-				C2B8417E093C94EA00975D56 /* Deployment */,
-				C2B8417F093C94EA00975D56 /* Default */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Default;
-		};
-		C2B84180093C94EA00975D56 /* Build configuration list for PBXNativeTarget "Creatures (Upgraded)" */ = {
+		C2B84180093C94EA00975D56 /* Build configuration list for PBXNativeTarget "Creatures" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				C2B84181093C94EA00975D56 /* Development */,

--- a/Creatures.xcodeproj/project.pbxproj
+++ b/Creatures.xcodeproj/project.pbxproj
@@ -1006,6 +1006,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.2;
 				PRODUCT_NAME = Creatures;
 				SECTORDER_FLAGS = "";
+				VALID_ARCHS = "ppc i386 x86_64";
 				WARNING_CFLAGS = "-Wall";
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = NO;
@@ -1033,6 +1034,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.2;
 				PRODUCT_NAME = Creatures;
 				SECTORDER_FLAGS = "";
+				VALID_ARCHS = "ppc i386 x86_64";
 				WARNING_CFLAGS = "-Wall";
 				WRAPPER_EXTENSION = app;
 				ZERO_LINK = NO;
@@ -1057,6 +1059,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.2;
 				PRODUCT_NAME = Creatures;
 				SECTORDER_FLAGS = "";
+				VALID_ARCHS = "ppc i386 x86_64";
 				WARNING_CFLAGS = "-Wall";
 				WRAPPER_EXTENSION = app;
 			};

--- a/Creatures.xcodeproj/project.pbxproj
+++ b/Creatures.xcodeproj/project.pbxproj
@@ -96,11 +96,9 @@
 		C29E01F00546DBE700B0215B /* help_language_reference.html in Resources */ = {isa = PBXBuildFile; fileRef = C28FAD0804DBC07600A800F6 /* help_language_reference.html */; };
 		C29E01F10546DBE700B0215B /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = C28FAD0B04DBED0600A800F6 /* index.html */; };
 		C29E01F20546DBE700B0215B /* screenshot.png in Resources */ = {isa = PBXBuildFile; fileRef = C28FAD0D04DBED2100A800F6 /* screenshot.png */; };
-		C29E01F30546DBE700B0215B /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = C27E7B1C04E3E22C00A800F6 /* index.html */; };
 		C29E01F40546DBE700B0215B /* Creatures.icns in Resources */ = {isa = PBXBuildFile; fileRef = C203017104F42A5F00A800F6 /* Creatures.icns */; };
 		C29E01F50546DBE700B0215B /* creatureinspectorwindow.png in Resources */ = {isa = PBXBuildFile; fileRef = C2C0C21705375316000001C9 /* creatureinspectorwindow.png */; };
 		C29E01F60546DBE700B0215B /* Creatures.png in Resources */ = {isa = PBXBuildFile; fileRef = C243A19F05380D95000001C9 /* Creatures.png */; };
-		C29E01F70546DBE700B0215B /* Creatures.png in Resources */ = {isa = PBXBuildFile; fileRef = C243A1A105380DAA000001C9 /* Creatures.png */; };
 		C29E01F80546DBE700B0215B /* ErrorPanel.nib in Resources */ = {isa = PBXBuildFile; fileRef = C243A1A305381585000001C9 /* ErrorPanel.nib */; };
 		C29E01FB0546DBE700B0215B /* EnterRegistration.nib in Resources */ = {isa = PBXBuildFile; fileRef = C2442376053DC919000001C9 /* EnterRegistration.nib */; };
 		C29E01FC0546DBE700B0215B /* RegistrationSplash.nib in Resources */ = {isa = PBXBuildFile; fileRef = C27BE7D0053EC3F9000001C9 /* RegistrationSplash.nib */; };
@@ -188,7 +186,6 @@
 		C22C5ADB04F1702A00A800F6 /* changelog */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = changelog; sourceTree = "<group>"; };
 		C22FFE1D0438D8B100D0BAF5 /* Language Reference */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Language Reference"; sourceTree = "<group>"; };
 		C243A19F05380D95000001C9 /* Creatures.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Creatures.png; sourceTree = "<group>"; };
-		C243A1A105380DAA000001C9 /* Creatures.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Creatures.png; sourceTree = "<group>"; };
 		C243A1A405381585000001C9 /* English */ = {isa = PBXFileReference; lastKnownFileType = wrapper.nib; name = English; path = English.lproj/ErrorPanel.nib; sourceTree = "<group>"; };
 		C243A1A60538185A000001C9 /* ErrorPanelController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ErrorPanelController.h; sourceTree = "<group>"; };
 		C243A1A70538185A000001C9 /* ErrorPanelController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ErrorPanelController.m; sourceTree = "<group>"; };
@@ -225,7 +222,6 @@
 		C27E7B1104E2914F00A800F6 /* Debug.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Debug.h; sourceTree = "<group>"; };
 		C27E7B1204E2914F00A800F6 /* Debug.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Debug.m; sourceTree = "<group>"; };
 		C27E7B1504E2B5A200A800F6 /* Creatures_Prefix.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Creatures_Prefix.h; sourceTree = "<group>"; };
-		C27E7B1C04E3E22C00A800F6 /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
 		C280144B056D74C600A1C266 /* MANSDataAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MANSDataAdditions.h; sourceTree = "<group>"; };
 		C280144C056D74C600A1C266 /* MANSDataAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MANSDataAdditions.m; sourceTree = "<group>"; };
 		C2846CBE0470AA0800000102 /* Guide.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Guide.txt; sourceTree = "<group>"; };
@@ -583,14 +579,6 @@
 			path = MAKeyedArchiver;
 			sourceTree = "<group>";
 		};
-		C27E7B1B04E3E20700A800F6 /* beta */ = {
-			isa = PBXGroup;
-			children = (
-				C27E7B1C04E3E22C00A800F6 /* index.html */,
-			);
-			path = beta;
-			sourceTree = "<group>";
-		};
 		C28FACF504DBB59200A800F6 /* Help */ = {
 			isa = PBXGroup;
 			children = (
@@ -613,8 +601,7 @@
 		C28FAD0A04DBECD400A800F6 /* Web Site */ = {
 			isa = PBXGroup;
 			children = (
-				C27E7B1B04E3E20700A800F6 /* beta */,
-				C243A1A105380DAA000001C9 /* Creatures.png */,
+				C243A19F05380D95000001C9 /* Creatures.png */,
 				C28FAD0B04DBED0600A800F6 /* index.html */,
 				C28FAD0D04DBED2100A800F6 /* screenshot.png */,
 			);
@@ -800,11 +787,9 @@
 				C29E01F00546DBE700B0215B /* help_language_reference.html in Resources */,
 				C29E01F10546DBE700B0215B /* index.html in Resources */,
 				C29E01F20546DBE700B0215B /* screenshot.png in Resources */,
-				C29E01F30546DBE700B0215B /* index.html in Resources */,
 				C29E01F40546DBE700B0215B /* Creatures.icns in Resources */,
 				C29E01F50546DBE700B0215B /* creatureinspectorwindow.png in Resources */,
 				C29E01F60546DBE700B0215B /* Creatures.png in Resources */,
-				C29E01F70546DBE700B0215B /* Creatures.png in Resources */,
 				C29E01F80546DBE700B0215B /* ErrorPanel.nib in Resources */,
 				C29E01FB0546DBE700B0215B /* EnterRegistration.nib in Resources */,
 				C29E01FC0546DBE700B0215B /* RegistrationSplash.nib in Resources */,

--- a/Creatures_Prefix.h
+++ b/Creatures_Prefix.h
@@ -7,7 +7,7 @@
  *
  */
 
-#define MAC_OS_X_VERSION_MAX_ALLOWED MAC_OS_X_VERSION_10_2
+//#define MAC_OS_X_VERSION_MAX_ALLOWED MAC_OS_X_VERSION_10_2
 
 #import <Cocoa/Cocoa.h>
 #import <Carbon/Carbon.h>

--- a/Credits.rtf
+++ b/Credits.rtf
@@ -4,6 +4,7 @@
 \pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\ql\qnatural
 
 \f0\fs22 \cf0 Programming by Michael Ash\
+with a few patches by Blair Sherman\
 \
 Logo by Doug Andrus\
 \

--- a/Custom Views/ToolInteractionView.m
+++ b/Custom Views/ToolInteractionView.m
@@ -19,6 +19,10 @@
 	controller = c;
 }
 
+// Just to stop Xcode from complaining; the real implementations are in CreaturesView.
+- (void)zoomIn:sender { zoomFactor *= 2; }
+- (void)zoomOut:sender { zoomFactor /= 2; }
+
 - (void)centerInView:(int)x :(int)y
 {
 	NSPoint point = NSMakePoint(x, (pixHeight - y - 1));

--- a/Debug.h
+++ b/Debug.h
@@ -17,6 +17,6 @@
 #define MyErrorLog(format...) LogError(YES, __FILE__, __FUNCTION__, __LINE__, format)
 #define MyNonfatalErrorLog(format...) LogError(NO, __FILE__, __FUNCTION__, __LINE__, format)
 
-void LogAssertionFailure(char *condition, char *file, char *function, int line, NSString *format, ...);
-void LogError(BOOL fatal, char *file, char *function, int line, NSString *format, ...);
+void LogAssertionFailure(const char *condition, const char *file, const char *function, int line, NSString *format, ...);
+void LogError(BOOL fatal, const char *file, const char *function, int line, NSString *format, ...);
 void LogUncaughtException(NSException *exception);

--- a/Debug.m
+++ b/Debug.m
@@ -13,7 +13,7 @@
 #import "StackTrace.h"
 
 
-void LogErrorv(BOOL fatal, char *file, char *function, int line, NSString *format, va_list args)
+void LogErrorv(BOOL fatal, const char *file, const char *function, int line, NSString *format, va_list args)
 {
 	NSString *userErrorString = [[NSString alloc] initWithFormat:format arguments:args];
 	NSString *error = [NSString stringWithFormat:@"Error occured at %s:%d (%s): %@", file, line, function, userErrorString];
@@ -31,7 +31,7 @@ void LogErrorv(BOOL fatal, char *file, char *function, int line, NSString *forma
 	[userErrorString release];
 }
 
-void LogAssertionFailure(char *condition, char *file, char *function, int line, NSString *format, ...)
+void LogAssertionFailure(const char *condition, const char *file, const char *function, int line, NSString *format, ...)
 {
 	va_list args;
 	va_start(args, format);
@@ -40,7 +40,7 @@ void LogAssertionFailure(char *condition, char *file, char *function, int line, 
 	abort();
 }
 
-void LogError(BOOL fatal, char *file, char *function, int line, NSString *format, ...)
+void LogError(BOOL fatal, const char *file, const char *function, int line, NSString *format, ...)
 {
 	va_list args;
 	va_start(args, format);

--- a/English.lproj/InfoPlist.strings
+++ b/English.lproj/InfoPlist.strings
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleGetInfoString</key>
-	<string>Creatures 1.1.1, Copyright 2003 Michael Ash.</string>
+	<string>Creatures 1.1.2, Copyright 2003 Michael Ash.</string>
 	<key>CFBundleName</key>
 	<string>Creatures</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Creatures 1.1.1</string>
+	<string>Creatures 1.1.2</string>
 	<key>NSHumanReadableCopyright</key>
 	<string>Copyright 2003 Michael Ash</string>
 </dict>

--- a/Info-Creatures__Upgraded_.plist
+++ b/Info-Creatures__Upgraded_.plist
@@ -26,7 +26,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Creatures</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Creatures 1.1.1, Copyright 2003 Michael Ash</string>
+	<string>Creatures 1.1.2, Copyright 2003 Michael Ash</string>
 	<key>CFBundleIconFile</key>
 	<string>Creatures.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -38,11 +38,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>Creatures 1.1.1</string>
+	<string>Creatures 1.1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.1</string>
+	<string>1.1.2</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/MAKeyedArchiver/MAKeyedArchiver.h
+++ b/MAKeyedArchiver/MAKeyedArchiver.h
@@ -47,6 +47,7 @@ int LengthOfType(const char *type);
 - (void)encodeFloat:(float)realv forKey:(NSString *)key;
 - (void)encodeDouble:(double)realv forKey:(NSString *)key;
 - (void)encodeBytes:(const uint8_t *)bytesp length:(unsigned)lenv forKey:(NSString *)key;
+- (void)encodeBytes:(const uint8_t *)bytesp length:(unsigned)lenv forKey:(NSString *)key bytesPerItem:(size_t)bpi;
 
 - (void)finishEncoding;
 

--- a/MAKeyedArchiver/MAKeyedArchiver.m
+++ b/MAKeyedArchiver/MAKeyedArchiver.m
@@ -280,12 +280,6 @@ int LengthOfType(const char *type)
 
 - (void)encodeBool:(BOOL)arg forKey:(NSString *)key
 {
-#ifdef __LITTLE_ENDIAN__
-	if( sizeof(BOOL) == 4 )
-		arg = CFSwapInt32HostToBig(arg);
-	else if( sizeof(BOOL) == 8 )
-		arg = CFSwapInt64HostToBig(arg);
-#endif
 	ENCODE_BODY;
 }
 
@@ -429,7 +423,6 @@ int LengthOfType(const char *type)
 		else
 			[obj encodeWithCoder:self]; // encode *everything*, whee
 		
-		//int minusOne = CFSwapInt32HostToBig(-1);
 		[archive appendBytes:&minusOne length:sizeof(minusOne)]; // end with minus one
 	}
 	

--- a/MAKeyedArchiver/MAKeyedArchiver.m
+++ b/MAKeyedArchiver/MAKeyedArchiver.m
@@ -431,7 +431,7 @@ int LengthOfType(const char *type)
 	while(![delayedEncodesTable isEmpty])
 	{
 		ObjectOffsetPair pair = [delayedEncodesTable pop];
-		unsigned int *pointer = [archive mutableBytes] + pair.offset;
+		int *pointer = [archive mutableBytes] + pair.offset;
 		if(*pointer != 0 && CFSwapInt32BigToHost(*pointer) != 0xdeadbeef) // these are the only two pre-existing values it can have
 		{
 			MyErrorLog(@"MAKeyedArchiver internal consistency failure; while writing a delayed object, an unexpected value was encountered at the write location");
@@ -443,19 +443,19 @@ int LengthOfType(const char *type)
 	NSEnumerator *enumerator;
 	NSString *str;
 
-	unsigned int *classTableOffset = [archive mutableBytes];
+	int *classTableOffset = [archive mutableBytes];
 	*classTableOffset = CFSwapInt32HostToBig([archive length]);
 	
 	enumerator = [[classTable strings] objectEnumerator];
 	while((str = [enumerator nextObject]))
 	{
-		unsigned int nameIndex = CFSwapInt32HostToBig([stringTable indexOfString:str]);
+		int nameIndex = CFSwapInt32HostToBig([stringTable indexOfString:str]);
 		int version = CFSwapInt32HostToBig([NSClassFromString(str) version]);
 		[archive appendBytes:&nameIndex length:sizeof(nameIndex)];
 		[archive appendBytes:&version length:sizeof(version)];
 	}
 
-	unsigned int *stringTableOffset = [archive mutableBytes] + 4;
+	int *stringTableOffset = [archive mutableBytes] + 4;
 	*stringTableOffset = CFSwapInt32HostToBig([archive length]);
 	
 	enumerator = [[stringTable strings] objectEnumerator];
@@ -468,7 +468,7 @@ int LengthOfType(const char *type)
 	NSData *compressedData = [archive zlibCompressed];
 	NSMutableData *returnData = [NSMutableData dataWithLength:MD5_DIGEST_LENGTH + 4];
 	// save magic cookie
-	unsigned int *magicCookieOffset = [returnData mutableBytes] + MD5_DIGEST_LENGTH;
+	int *magicCookieOffset = [returnData mutableBytes] + MD5_DIGEST_LENGTH;
 	*magicCookieOffset = CFSwapInt32HostToBig('MAkA');
 	
 	// save MD5

--- a/MAKeyedArchiver/MAKeyedArchiver.m
+++ b/MAKeyedArchiver/MAKeyedArchiver.m
@@ -14,6 +14,7 @@
 #import "MAObjectOffsetStack.h"
 #import "MAObjectStack.h"
 #import "MANSDataAdditions.h"
+#import <CoreFoundation/CFByteOrder.h>
 
 
 /*

--- a/MAKeyedArchiver/MAKeyedUnarchiver.h
+++ b/MAKeyedArchiver/MAKeyedUnarchiver.h
@@ -38,6 +38,7 @@
 - (float)decodeFloatForKey:(NSString *)key;
 - (double)decodeDoubleForKey:(NSString *)key;
 - (const uint8_t *)decodeBytesForKey:(NSString *)key returnedLength:(unsigned *)lengthp;
+- (const uint8_t *)decodeBytesForKey:(NSString *)key returnedLength:(unsigned *)lengthp bytesPerItem:(size_t)bpi;
 
 - (void)finishDecoding;
 

--- a/MAKeyedArchiver/MAKeyedUnarchiver.m
+++ b/MAKeyedArchiver/MAKeyedUnarchiver.m
@@ -250,6 +250,7 @@
 		
 		int classTableOffset = CFSwapInt32BigToHost(*((int *)([archive bytes])));
 		int stringTableOffset = CFSwapInt32BigToHost(*((int *)([archive bytes] + 4)));
+		int offset;
 		
 		if(classTableOffset >= [archive length] || stringTableOffset >= [archive length])
 		{
@@ -258,7 +259,7 @@
 		
 		
 		// load the string table first, we need it to make the class table
-		int offset = stringTableOffset;
+		offset = stringTableOffset;
 		while(offset < [archive length])
 		{
 			[stringTable addObject:[NSString stringWithUTF8String:[archive bytes] + offset]];

--- a/MAKeyedArchiver/MANSDataAdditions.m
+++ b/MAKeyedArchiver/MANSDataAdditions.m
@@ -22,14 +22,14 @@
 	
 	[outData setLength:destLen]; // truncate to what's used
 	
-	unsigned sourceLength = [self length];
+	unsigned sourceLength = CFSwapInt32HostToBig([self length]);
 	[outData appendBytes:&sourceLength length:sizeof(sourceLength)]; // we need the original length, so stick it on the end
 	return outData;
 }
 
 - (NSData *)zlibDecompressed
 {
-	uLongf originalLength = *((int *)([self bytes] + [self length] - 4));
+	uLongf originalLength = CFSwapInt32BigToHost(*((int *)([self bytes] + [self length] - 4)));
 	NSMutableData *outData = [NSMutableData dataWithLength:originalLength];
 	if(uncompress([outData mutableBytes], &originalLength, [self bytes], [self length] - 4) != Z_OK)
 		return nil;

--- a/Misc Model Classes/Genome.m
+++ b/Misc Model Classes/Genome.m
@@ -631,7 +631,7 @@ static int SortFunction(id a, id b, void *context)
 
 - initWithCoder:(NSCoder *)coder
 {
-	//parent = [coder decodeObjectForKey:@"parent"];
+	parent = [coder decodeObjectForKey:@"parent"];
 	if([coder containsValueForKey:@"children"])
 		children = [[coder decodeObjectForKey:@"children"] retain];
 	[children makeObjectsPerformSelector:@selector(setParent:) withObject:self];

--- a/Misc Model Classes/Genome.m
+++ b/Misc Model Classes/Genome.m
@@ -631,7 +631,7 @@ static int SortFunction(id a, id b, void *context)
 
 - initWithCoder:(NSCoder *)coder
 {
-	parent = [coder decodeObjectForKey:@"parent"];
+	//parent = [coder decodeObjectForKey:@"parent"];
 	if([coder containsValueForKey:@"children"])
 		children = [[coder decodeObjectForKey:@"children"] retain];
 	[children makeObjectsPerformSelector:@selector(setParent:) withObject:self];

--- a/Misc Model Classes/GenomeLibrary.m
+++ b/Misc Model Classes/GenomeLibrary.m
@@ -8,6 +8,7 @@
 
 #import "GenomeLibrary.h"
 #import "Genome.h"
+#import <CoreFoundation/CFByteOrder.h>
 
 
 @interface GenomeLibrary (Private)
@@ -32,8 +33,10 @@
 
 - initFromDefaults
 {
-	// Commented out because unarchiveObjectWithData sometimes hangs in release builds!
-	/*
+#ifdef __LITTLE_ENDIAN__
+	// Because unarchiveObjectWithData sometimes hangs here in Intel release builds.
+	library = [[NSMutableSet alloc] init];
+#else
 	NSData *libraryData = [[NSUserDefaults standardUserDefaults] objectForKey:@"GenomeLibrary"];
 	if(libraryData)
 	{
@@ -44,8 +47,7 @@
 	{
 		library = [[NSMutableSet alloc] init];
 	}
-	*/
-	library = [[NSMutableSet alloc] init];
+#endif
 	return self;
 }
 

--- a/Misc Model Classes/GenomeLibrary.m
+++ b/Misc Model Classes/GenomeLibrary.m
@@ -33,10 +33,6 @@
 
 - initFromDefaults
 {
-#ifdef __LITTLE_ENDIAN__
-	// Because unarchiveObjectWithData sometimes hangs here in Intel release builds.
-	library = [[NSMutableSet alloc] init];
-#else
 	NSData *libraryData = [[NSUserDefaults standardUserDefaults] objectForKey:@"GenomeLibrary"];
 	if(libraryData)
 	{
@@ -47,7 +43,6 @@
 	{
 		library = [[NSMutableSet alloc] init];
 	}
-#endif
 	return self;
 }
 

--- a/Misc Model Classes/GenomeLibrary.m
+++ b/Misc Model Classes/GenomeLibrary.m
@@ -8,7 +8,6 @@
 
 #import "GenomeLibrary.h"
 #import "Genome.h"
-#import <CoreFoundation/CFByteOrder.h>
 
 
 @interface GenomeLibrary (Private)

--- a/Misc Model Classes/GenomeLibrary.m
+++ b/Misc Model Classes/GenomeLibrary.m
@@ -32,6 +32,8 @@
 
 - initFromDefaults
 {
+	// Commented out because unarchiveObjectWithData sometimes hangs in release builds!
+	/*
 	NSData *libraryData = [[NSUserDefaults standardUserDefaults] objectForKey:@"GenomeLibrary"];
 	if(libraryData)
 	{
@@ -42,6 +44,8 @@
 	{
 		library = [[NSMutableSet alloc] init];
 	}
+	*/
+	library = [[NSMutableSet alloc] init];
 	return self;
 }
 

--- a/PixmapUtils.m
+++ b/PixmapUtils.m
@@ -10,17 +10,19 @@
 
 void EncodePixel24(Pixel24 p, NSCoder *coder)
 {
-	[coder encodeValueOfObjCType:@encode(int) at:&p.r];
-	[coder encodeValueOfObjCType:@encode(int) at:&p.g];
-	[coder encodeValueOfObjCType:@encode(int) at:&p.b];
+	int r = CFSwapInt32HostToBig(p.r << 24), g = CFSwapInt32HostToBig(p.g << 24), b = CFSwapInt32HostToBig(p.b << 24);
+	[coder encodeValueOfObjCType:@encode(int) at:&r];
+	[coder encodeValueOfObjCType:@encode(int) at:&g];
+	[coder encodeValueOfObjCType:@encode(int) at:&b];
 }
 
 Pixel24 DecodePixel24(NSCoder *coder)
 {
-	Pixel24 p;
-	[coder decodeValueOfObjCType:@encode(int) at:&p.r];
-	[coder decodeValueOfObjCType:@encode(int) at:&p.g];
-	[coder decodeValueOfObjCType:@encode(int) at:&p.b];
+	int r = 0, g = 0, b = 0;
+	[coder decodeValueOfObjCType:@encode(int) at:&r];
+	[coder decodeValueOfObjCType:@encode(int) at:&g];
+	[coder decodeValueOfObjCType:@encode(int) at:&b];
+	Pixel24 p = { .r = CFSwapInt32BigToHost(r) >> 24, .g = CFSwapInt32BigToHost(g) >> 24, .b = CFSwapInt32BigToHost(b) >> 24 };
 	return p;
 }
 

--- a/Tool Classes/SquareTool.m
+++ b/Tool Classes/SquareTool.m
@@ -26,6 +26,9 @@
 
 	[GUIObject setImage:squareToolImage];
 	[GUIObject setImagePosition:NSImageOnly];
+	
+	// Select this tool at startup.
+	[controller changeTool:2];
 }
 
 - (void)unregisterTrackingRect

--- a/Virtual Machine/VirtualMachine.h
+++ b/Virtual Machine/VirtualMachine.h
@@ -75,6 +75,8 @@ typedef union {
 	int raw;
 } VMInstruction;
 
+int getRawBigFromInst( VMInstruction inst );
+VMInstruction getInstFromRawBig( int rawBig );
 
 #define VM_NUM_REGS 32
 #define VM_REG_MASK (0x1F)

--- a/Virtual Machine/VirtualMachine.m
+++ b/Virtual Machine/VirtualMachine.m
@@ -403,7 +403,7 @@ VMInstruction getInstFromRawBig( int rawBig )
 
 	PC = [coder decodeIntForKey:@"PC"];
 
-	int rlen;
+	unsigned rlen;
 	int *rtemp = (void *)[coder decodeBytesForKey:@"rbytes" returnedLength:&rlen];
 	if(sizeof(r) < rlen)
 		rlen = sizeof(r);

--- a/Virtual Machine/VirtualMachine.m
+++ b/Virtual Machine/VirtualMachine.m
@@ -403,9 +403,8 @@ VMInstruction getInstFromRawBig( int rawBig )
 
 	PC = [coder decodeIntForKey:@"PC"];
 
-	unsigned int rlen = 0;
-	const int *rtemp = (const void*)[coder decodeBytesForKey:@"rbytes" returnedLength:&rlen];
-
+	int rlen;
+	int *rtemp = (const void*)[coder decodeBytesForKey:@"rbytes" returnedLength:&rlen];
 	if(sizeof(r) < rlen)
 		rlen = sizeof(r);
 

--- a/Virtual Machine/VirtualMachine.m
+++ b/Virtual Machine/VirtualMachine.m
@@ -385,7 +385,7 @@ VMInstruction getInstFromRawBig( int rawBig )
 #endif
 	
 	unsigned templen;
-	const unsigned int *temp = (const void*)[coder decodeBytesForKey:@"memoryBytes" returnedLength:&templen];
+	int *temp = (void *)[coder decodeBytesForKey:@"memoryBytes" returnedLength:&templen];
 
 	if(memory)
 		free(memory);
@@ -404,7 +404,7 @@ VMInstruction getInstFromRawBig( int rawBig )
 	PC = [coder decodeIntForKey:@"PC"];
 
 	int rlen;
-	int *rtemp = (const void*)[coder decodeBytesForKey:@"rbytes" returnedLength:&rlen];
+	int *rtemp = (void *)[coder decodeBytesForKey:@"rbytes" returnedLength:&rlen];
 	if(sizeof(r) < rlen)
 		rlen = sizeof(r);
 

--- a/Virtual Machine/VirtualMachine.m
+++ b/Virtual Machine/VirtualMachine.m
@@ -8,6 +8,7 @@
 
 #import "VirtualMachine.h"
 #import "VirtualMachineAssembler.h"
+#import <CoreFoundation/CFByteOrder.h>
 
 
 int getRawBigFromInst( VMInstruction inst )

--- a/Virtual Machine/VirtualMachineAssembler.m
+++ b/Virtual Machine/VirtualMachineAssembler.m
@@ -197,11 +197,11 @@ static NSString *trapStrings[] = {
 			return [NSString stringWithFormat:@"%@\tr%d", opString, inst.special.reg];
 			break;
 		default:
-			#ifdef __LITTLE_ENDIAN__
-				return [NSString stringWithFormat:@"%@\t%d", opString, CFSwapInt32BigToHost(getRawBigFromInst(inst))];
-			#else
-				return [NSString stringWithFormat:@"%@\t%d", opString, inst.raw];
-			#endif
+#ifdef __LITTLE_ENDIAN__
+			return [NSString stringWithFormat:@"%@\t%d", opString, CFSwapInt32BigToHost(getRawBigFromInst(inst))];
+#else
+			return [NSString stringWithFormat:@"%@\t%d", opString, inst.raw];
+#endif
 			break;
 	}
 }
@@ -482,11 +482,11 @@ static NSString *trapStrings[] = {
 			if(token == nil)
 				curLineInstruction.loadi.opcode = opNop;
 			else
-				#ifdef __LITTLE_ENDIAN__
-					curLineInstruction = getInstFromRawBig(CFSwapInt32HostToBig([self convertToNumber:token]));
-				#else
-					curLineInstruction.raw = [self convertToNumber:token];
-				#endif
+#ifdef __LITTLE_ENDIAN__
+				curLineInstruction = getInstFromRawBig(CFSwapInt32HostToBig([self convertToNumber:token]));
+#else
+				curLineInstruction.raw = [self convertToNumber:token];
+#endif
 		}
 
 

--- a/Virtual Machine/VirtualMachineAssembler.m
+++ b/Virtual Machine/VirtualMachineAssembler.m
@@ -143,7 +143,7 @@ static NSString *trapStrings[] = {
 			if(inst.load.op_is_address)
 				return [NSString stringWithFormat:@"%@\t%d", str, inst.load.addr];
 			else
-				return [NSString stringWithFormat:@"%@\tr%d", str, (inst.load.addr & VM_REG_MASK)];
+				return [NSString stringWithFormat:@"%@\tr%d", str, inst.load.addr & VM_REG_MASK];
 			break;
 		}
 		case opJumpEQZ:
@@ -159,7 +159,7 @@ static NSString *trapStrings[] = {
 			if(inst.load.op_is_address)
 				return [NSString stringWithFormat:@"%@\t%d", str, inst.load.addr];
 			else
-				return [NSString stringWithFormat:@"%@\tr%d", str, (inst.load.addr & VM_REG_MASK)];
+				return [NSString stringWithFormat:@"%@\tr%d", str, inst.load.addr & VM_REG_MASK];
 			break;
 		}
 		case opJump:
@@ -172,7 +172,7 @@ static NSString *trapStrings[] = {
 			if(inst.load.op_is_address)
 				return [NSString stringWithFormat:@"%@\t%d", str, inst.load.addr];
 			else
-				return [NSString stringWithFormat:@"%@\tr%d", str, (inst.load.addr & VM_REG_MASK)];
+				return [NSString stringWithFormat:@"%@\tr%d", str, inst.load.addr & VM_REG_MASK];
 			break;
 		}
 		case opLoadi:
@@ -758,6 +758,7 @@ static NSString *trapStrings[] = {
 		/*
 		 --------------- special opcode end -------------
 		 */
+		
 		
 		else
 		{

--- a/Virtual Machine/VirtualMachineAssembler.m
+++ b/Virtual Machine/VirtualMachineAssembler.m
@@ -9,6 +9,7 @@
 #import "VirtualMachineAssembler.h"
 #import "VirtualMachine.h"
 #import "VirtualMachineError.h"
+#import <CoreFoundation/CFByteOrder.h>
 
 
 @interface AssemblerLabelReference : NSObject {

--- a/Window Controllers/GenomeWindowController.h
+++ b/Window Controllers/GenomeWindowController.h
@@ -32,6 +32,6 @@
 - (void)showParent:sender;
 - (void)showDisassembly:sender;
 - (void)showCOG:sender;
-- (void)setColor:sender;
+- (void)setColor:(NSColorWell *)sender;
 
 @end

--- a/changelog
+++ b/changelog
@@ -4,11 +4,9 @@ Universal binary, with some tricks on Intel to make sure VM arithmetic acts like
 
 Fixed speed control values from 1:1 to 32:1, which seemed to be unbounded on fast CPUs.
 
-Assembler now correctly checks the LdI value range.
-
 Fixed the "Save As" filename and default directory when re-saving.
 
-Fixed a couple issues with resource files having the same name.
+Fixed a couple issues with app resource files having the same name.
 
 Automatically select square tool when making a new arena, and inspect tool after loading an arena.
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,17 @@
+1.1.2
+-----
+Universal binary, with some tricks on Intel to make sure VM arithmetic acts like it would on PowerPC.
+
+Fixed speed control values from 1:1 to 32:1, which seemed to be unbounded on fast CPUs.
+
+Assembler now correctly checks the LdI value range.
+
+Fixed the "Save As" filename and default directory when re-saving.
+
+Fixed a couple issues with resource files having the same name.
+
+Automatically select square tool when making a new arena, and inspect tool after loading an arena.
+
 beta 7
 ------
 Fixed a dumb bug that caused an uncaught exception if the inspector was used on a barrier.


### PR DESCRIPTION
This builds as a universal binary in [Xcode 3.2.6 with GCC 4.0 and the 10.4u SDK](http://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_3.2.6_and_ios_sdk_4.3__final/xcode_3.2.6_and_ios_sdk_4.3.dmg) but unfortunately has some code that's incompatible with newer Mac OS X SDKs.

To save you some hassle, here is the compiled program: [Creatures 1.1.2 universal.zip](https://github.com/mikeash/creatures/files/1250536/Creatures.1.1.2.universal.zip)

**Changes:**

Universal binary, with some tricks on Intel to make sure VM arithmetic acts like it would on PowerPC.  (Divide by zero, modulo zero, etc.)

Fixed speed control values from 1:1 to 32:1, which seemed to be unbounded on fast CPUs.

Fixed the "Save As" filename and default directory when re-saving.

Fixed a couple issues with app resource files having the same name.

Automatically select square tool when making a new arena, and inspect tool after loading an arena.

Cleaned up a few things causing compiler warnings.